### PR TITLE
Feat/#24/onboarding-progressbar

### DIFF
--- a/src/commons/navigation/Stepper/index.tsx
+++ b/src/commons/navigation/Stepper/index.tsx
@@ -1,0 +1,20 @@
+interface StepperProps {
+  currentStep: number; // 1-based index
+}
+
+const Stepper = ({ currentStep }: StepperProps) => {
+  return (
+    <div className="w-full flex justify-start items-center gap-2">
+      {[1, 2, 3].map((step) => (
+        <div
+          key={step}
+          className={`flex-1 h-2.5 rounded-[20px] ${
+            step === currentStep ? "bg-third" : "bg-[#d9d9d9]"
+          }`}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Stepper;

--- a/src/commons/navigation/Stepper/index.tsx
+++ b/src/commons/navigation/Stepper/index.tsx
@@ -4,12 +4,16 @@ interface StepperProps {
 
 const Stepper = ({ currentStep }: StepperProps) => {
   return (
-    <div className="w-full flex justify-start items-center gap-2">
+    <div className="w-full p-3 flex justify-start items-center gap-2">
       {[1, 2, 3].map((step) => (
         <div
           key={step}
           className={`flex-1 h-2.5 rounded-[20px] ${
-            step === currentStep ? "bg-third" : "bg-[#d9d9d9]"
+            step === currentStep
+              ? "bg-third"
+              : step < currentStep
+                ? "bg-main"
+                : "bg-[#d9d9d9]"
           }`}
         />
       ))}

--- a/src/services/auth/login/index.tsx
+++ b/src/services/auth/login/index.tsx
@@ -19,10 +19,9 @@ function LoginPage() {
   };
 
   return (
-    <div className="flex flex-col justify-between min-h-screen relative overflow-hidden z-0 bg-[#ffffff]">
+    <div className="flex flex-col justify-between relative overflow-hidden z-0 bg-white">
+      <GlobalNavigation />
       <div className="relative z-10 p-[20px]">
-        <GlobalNavigation />
-
         <main className="flex flex-col flex-1 relative z-0">
           <h2 className="text-[24px] text-font-color text-gray-5 my-4 font-normal">
             Hello
@@ -40,7 +39,7 @@ function LoginPage() {
           </p>
         </main>
       </div>
-      <div className="flex relative mt-[-20px]">
+      <div className="flex relative">
         <div className="w-full max-w-[393px] relative">
           <AuthBg className="w-full h-auto" />
           <div className="absolute inset-0 flex mt-[80%] w-full">

--- a/src/services/auth/login/index.tsx
+++ b/src/services/auth/login/index.tsx
@@ -19,7 +19,7 @@ function LoginPage() {
   };
 
   return (
-    <div className="flex flex-col justify-between relative overflow-hidden z-0 bg-white">
+    <div className="flex flex-col justify-between min-h-screen relative overflow-hidden z-0 bg-white">
       <GlobalNavigation />
       <div className="relative z-10 p-[20px]">
         <main className="flex flex-col flex-1 relative z-0">
@@ -28,7 +28,7 @@ function LoginPage() {
           </h2>
           <p className="text-4xl sm:text-4xl md:text-5xl font-extrabold font-[figtree] leading-tight sm:leading-[56px] pb-6 md:pb-8">
             Is this
-            <br className="hidden sm:block" />
+            <br />
             your first time
             <br />
             using <span className="text-second">OnDaum?</span>

--- a/src/services/onboarding/additional/concern/index.tsx
+++ b/src/services/onboarding/additional/concern/index.tsx
@@ -36,6 +36,7 @@ function OnboardingConcernPage() {
         subName: "I don't want to share my worries",
         disabled: isDisabled,
       }}
+      currentStep={2}
     >
       {CONCERN_KEY.map((key) => (
         <article key={key} className="mb-6">

--- a/src/services/onboarding/additional/emotion/index.tsx
+++ b/src/services/onboarding/additional/emotion/index.tsx
@@ -27,6 +27,7 @@ function OnboardingEmotionPage() {
         name: "Finish choosing your mind",
         onPress: goCompletePage,
       }}
+      currentStep={3}
     >
       {emotion}
     </OnboardingAdditionalLayout>

--- a/src/services/onboarding/additional/layout.tsx
+++ b/src/services/onboarding/additional/layout.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { ReactNode } from "react";
 import Button from "../../../commons/inputs/Button";
+import Stepper from "../../../commons/navigation/Stepper";
 
 export interface OnboardingLayoutProps {
   title: ReactNode;
@@ -11,15 +12,18 @@ export interface OnboardingLayoutProps {
     subName?: string;
     disabled?: boolean;
   };
+  currentStep?: number;
 }
 
 function OnboardingAdditionalLayout({
   title,
   children,
   button,
+  currentStep,
 }: OnboardingLayoutProps) {
   return (
     <main className="pb-44">
+      {typeof currentStep === "number" && <Stepper currentStep={currentStep} />}
       {title}
       {children}
       {button && (

--- a/src/services/onboarding/basic/index.tsx
+++ b/src/services/onboarding/basic/index.tsx
@@ -42,6 +42,7 @@ function OnboardingBasicPage() {
         name: "Enter your information",
         onPress: goConcernPage,
       }}
+      currentStep={1}
     >
       <article className="mb-6">
         <h5 className="text-xl font-['Pretendard'] font-bold mb-2">Sex</h5>


### PR DESCRIPTION
### 🥕 ISSUE

- closed #24 

---

### ✅ Key Changes

1. 온보딩 상태 stepper 추가
2. auth page 레이아웃 수정(bg color, 중앙 정렬)

---

### 📢 To Reviewers

1. 온보딩 페이지에서 bottom navigation 나오지 않도록 수정해야 합니다!
2. 뒤로가기 버튼 제외하고 stepper만 구현했습니다.

---

### 📸 ScreenShot
<img width="318" alt="image" src="https://github.com/user-attachments/assets/8e8b54b7-41a4-44d2-ab74-2df3e2ce4700" />

<img width="320" alt="image" src="https://github.com/user-attachments/assets/b14c9e46-c03c-4802-9773-35d91e494cfc" />